### PR TITLE
CI/dependabot なら reg-ci をrunさせない

### DIFF
--- a/.github/workflows/reg.yaml
+++ b/.github/workflows/reg.yaml
@@ -12,6 +12,7 @@ env:
 
 jobs:
   build:
+    if: ${{ github.actor != 'dependabot[bot]' }}
     runs-on: ubuntu-latest
 
     strategy:


### PR DESCRIPTION
resolve: https://github.com/Doer-org/glyph/issues/97