### PR TITLE
Server/migarationツールをsql-migrateからgolang-migrateに置き換える

### DIFF
--- a/server/migrations/000001_create_table.down.sql
+++ b/server/migrations/000001_create_table.down.sql
@@ -1,7 +1,3 @@
-
--- +migrate Up
-
-
 CREATE TABLE `users` (
   `id`        varchar(255) COLLATE utf8mb4_bin NOT NULL ,
   `name`      varchar(255) COLLATE utf8mb4_bin NOT NULL,
@@ -59,5 +55,3 @@ CREATE TABLE `images` (
   PRIMARY KEY (`id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin;
 
-
--- +migrate Down


### PR DESCRIPTION
feat : https://github.com/Doer-org/glyph/issues/106
なんでこの技術選定をしたこというと
* CDで一緒に動作させる必要がある。
* DockerfileでGCPでデプロイさせる方法を考えていたが、上手くいかなかった+運用費が余計にかかる
* そのため、github-actionsでコマンドを実行させる方法を考えたが、sql-migrateでは設定fileにdsnを書く必要がありセキュリティ上難しいので、コマンドでdsnを渡せるgolang-migrationに移行させた。