### PR TITLE
ログインしているユーザーのglyphのページへのリダイレクト

### DIFF
--- a/client/src/app/(top)/page.tsx
+++ b/client/src/app/(top)/page.tsx
@@ -1,7 +1,18 @@
+import { NextPage } from 'next'
+import { redirect } from 'next/navigation'
+
+import { getLoggedInUser } from '@/api'
+import { getToken } from '@/api/utils/token'
+
 import { DiscordLink } from './_components/discordLink'
 import { IntroduceContents } from './_components/introduceContents'
 
 const Top = async () => {
+  const token = getToken()
+  const user = await getLoggedInUser(token)
+  if (user.type === 'ok') {
+    redirect('/glyphs/')
+  }
   return (
     <>
       <IntroduceContents />
@@ -9,4 +20,5 @@ const Top = async () => {
     </>
   )
 }
+
 export default Top


### PR DESCRIPTION
Token残ってはるユーザーさんはglyphのページに飛んでもらいます。
これでglyphクリックしてもTopページではなくglyphページを見てもらえるようになりました。

https://github.com/Doer-org/glyph/assets/102772040/0a02b585-f409-4f77-8401-10c819893336

